### PR TITLE
Update docker-run.sh for overriding etc folder after instance creation

### DIFF
--- a/artemis-docker/docker-run.sh
+++ b/artemis-docker/docker-run.sh
@@ -40,6 +40,9 @@ echo CREATE_ARGUMENTS=${CREATE_ARGUMENTS}
 
 if ! [ -f ./etc/broker.xml ]; then
     /opt/activemq-artemis/bin/artemis create ${CREATE_ARGUMENTS} .
+    if [ -d ./etc-override ]; then
+        for file in `ls ./etc-override`; do echo copying file to etc folder: $file; cp ./etc-override/$file ./etc || :; done
+    fi
 else
     echo "broker already created, ignoring creation"
 fi


### PR DESCRIPTION
If a folder named etc-override exists inside instance folder, its contents will be copied to etc folder after instance creation. 

This change will make it possible to run to broker with user supplied broker.xml or artemis.profile files, by using a simple volume mapping with docker.